### PR TITLE
fix: transform pattern before parse mask

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -22,7 +22,8 @@ export default function App() {
 				<Input value={state.cellTelephone} onChange={onChange} mask="cellTelephone" name="cellTelephone" placeholder="cellTelephone" />
 				<Input value={state.cellphone} onChange={onChange} mask="cellphone" name="cellphone" placeholder="cellphone" />
 				<Input value={state.cep} onChange={onChange} mask="cep" name="cep" placeholder="cep" />
-				<Input value={state.cnpj} onChange={onChange} mask="cnpj" name="cnpj" placeholder="cpfCnpj" />
+				<Input value={state.cnpj} onChange={onChange} mask="cnpj" name="cnpj" placeholder="cnpj" />
+				<Input value={state.cpfCnpj} onChange={onChange} mask="cpfCnpj" name="cpfCnpj" placeholder="cpfCnpj" />
 				<Input value={state.color} onChange={onChange} mask="color" name="color" placeholder="color" />
 				<Input value={state.cpf} onChange={onChange} mask="cpf" name="cpf" placeholder="cpf" />
 				<Input value={state.creditCard} onChange={onChange} mask="creditCard" name="creditCard" placeholder="creditCard" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "the-mask-input",
-	"version": "3.0.5",
+	"version": "3.0.6",
 	"description": "A simple way to create inputs with masked values. Works like `<input />`, but apply mask for your values.",
 	"author": "g4rcez",
 	"readme": "./README.md",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "the-mask-input",
-	"version": "3.0.4",
+	"version": "3.0.5",
 	"description": "A simple way to create inputs with masked values. Works like `<input />`, but apply mask for your values.",
 	"author": "g4rcez",
 	"readme": "./README.md",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
 		"build": "rollup -c --bundleConfigAsCjs",
 		"cypress": "cypress open",
 		"test": "cypress run",
-		"dev": "rollup -c --watch",
-		"prepare": "rollup -c",
+		"dev": "rollup -c --watch --bundleConfigAsCjs",
+		"prepare": "pnpm build",
 		"format": "prettier --write \"{.,src/**}/*.{js,jsx,ts,tsx}\""
 	},
 	"peerDependencies": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,8 @@ import React, { useMemo } from "react";
 
 export { CurrencyInput, CurrencyInput as MoneyInput } from "./currency-input";
 export { masks, inputMaskedProps } from "./masks";
+export type { TheMaskPropsMerge as TheMaskProps } from "./input";
+export type { CurrencyInputProps } from "./currency-input";
 
 const Component = (mask: MaskConfig) => (props: TheMaskPropsMerge) => <TheMaskInput {...mask} {...(props as any)} />;
 

--- a/src/input.tsx
+++ b/src/input.tsx
@@ -3,7 +3,8 @@ import { Mask, TheMaskInputProps, TheMasks, Token, Tokens } from "./types";
 import { originalTokens } from "./masks";
 import { CurrencyInput, CurrencyInputProps } from "./currency-input";
 
-function formatRegexMask(value: string, mask: string | Mask[], tokens: Tokens = originalTokens) {
+function formatRegexMask(v: string, mask: string | Mask[], transform: (x: string) => string, tokens: Tokens = originalTokens) {
+	const value = transform(v);
 	let output = "";
 	for (let countMask = 0, i = 0; countMask < mask.length && i < value.length; ) {
 		const maskChar = mask[countMask];
@@ -25,8 +26,6 @@ function formatRegexMask(value: string, mask: string | Mask[], tokens: Tokens = 
 	return output;
 }
 
-const applyMask = (value: string, mask: TheMasks, tokens: Tokens) => formatRegexMask(value, typeof mask === "function" ? mask(value) : mask, tokens);
-
 export const createPattern = (mask: TheMasks, value: string) => {
 	const maskIsFunction = typeof mask === "function";
 	let result: string | Mask[] = maskIsFunction ? "" : mask;
@@ -46,50 +45,52 @@ export const createPattern = (mask: TheMasks, value: string) => {
 	return "";
 };
 
-const MaskInput = forwardRef<HTMLInputElement, TheMaskInputProps>(({ onChange, pattern, tokens, mask, onChangeText, as, ...props }, ref) => {
-	const Component = as ?? "input";
-	const internalRef = useRef<HTMLInputElement>(null);
-	useImperativeHandle(ref, () => internalRef.current!);
-	const [stateValue, setStateValue] = useState(props.value ?? props.defaultValue ?? "");
+const noop = (s: string) => s;
 
-	const patternMemo = useMemo(() => {
-		if (pattern) return pattern;
-		if (mask === undefined) return;
-		return createPattern(mask, stateValue);
-	}, [pattern, stateValue]);
+const MaskInput = forwardRef<HTMLInputElement, TheMaskInputProps>(
+	({ onChange, transform, pattern, tokens, mask, onChangeText, as, ...props }, ref) => {
+		const Component = as ?? "input";
+		const internalRef = useRef<HTMLInputElement>(null);
+		useImperativeHandle(ref, () => internalRef.current!);
+		const [stateValue, setStateValue] = useState(props.value ?? props.defaultValue ?? "");
 
-	const changeMask = (event: ChangeEvent<HTMLInputElement>) => {
-		const value = event.target.value;
-		if (mask === undefined) {
-			setStateValue(value);
-			onChangeText?.(value);
-			return onChange?.(event);
-		}
-		const refInput = event.target;
-		let caret = refInput.selectionEnd ?? 0;
-		const digit = value[caret - 1];
-		const masked = applyMask(value, mask, tokens ?? originalTokens);
-		refInput.value = masked;
-		if (masked === stateValue) return;
-		setStateValue(masked);
-		onChangeText?.(masked);
-		while (caret < masked.length && masked.charAt(caret - 1) !== digit) {
-			caret += 1;
-		}
-		if (refInput !== document.activeElement) {
-			refInput.setSelectionRange(caret, caret);
-		}
-		event.target.value = masked;
-		onChange?.(event);
-	};
-	return <Component {...props} pattern={patternMemo} onChange={changeMask} value={stateValue} ref={internalRef} />;
-});
+		const patternMemo = useMemo(() => {
+			if (pattern) return pattern;
+			if (mask === undefined) return;
+			return createPattern(mask, stateValue);
+		}, [pattern, stateValue]);
+
+		const changeMask = (event: ChangeEvent<HTMLInputElement>) => {
+			const value = event.target.value;
+			if (mask === undefined) {
+				setStateValue(value);
+				onChangeText?.(value);
+				return onChange?.(event);
+			}
+			const refInput = event.target;
+			let caret = refInput.selectionEnd ?? 0;
+			const digit = value[caret - 1];
+			const masked = formatRegexMask(value, typeof mask === "function" ? mask(value) : mask, transform ?? noop, tokens ?? originalTokens);
+			refInput.value = masked;
+			if (masked === stateValue) return;
+			setStateValue(masked);
+			onChangeText?.(masked);
+			while (caret < masked.length && masked.charAt(caret - 1) !== digit) {
+				caret += 1;
+			}
+			if (refInput !== document.activeElement) {
+				refInput.setSelectionRange(caret, caret);
+			}
+			event.target.value = masked;
+			onChange?.(event);
+		};
+		return <Component {...props} pattern={patternMemo} onChange={changeMask} value={stateValue} ref={internalRef} />;
+	}
+);
 
 export type TheMaskPropsMerge = (TheMaskInputProps & { mask?: TheMaskInputProps["mask"] }) | (CurrencyInputProps & { mask?: "money" | "currency" });
 
 export const TheMaskInput = forwardRef<HTMLInputElement, TheMaskPropsMerge>((props, externalRef) => {
-	if (props.mask === "currency" || props.mask === "money") {
-		return <CurrencyInput {...props} mask={undefined} ref={externalRef} />;
-	}
-	return <MaskInput {...props} ref={externalRef} />;
+	const isCurrency = props.mask === "currency" || props.mask === "money";
+	return isCurrency ? <CurrencyInput {...props} mask={undefined} ref={externalRef} /> : <MaskInput {...props} ref={externalRef} />;
 });

--- a/src/masks.ts
+++ b/src/masks.ts
@@ -63,12 +63,12 @@ export const masks: Record<Masks, TheMasks> = {
 	int: (s) => (digit.test(s.slice(-1)) ? "d".repeat(Math.max(s.length, 0)) : "d".repeat(Math.max(s.length - 1, 0)))
 };
 
-export type MaskConfig = { pattern?: string; inputMode: InputMode; mask: TheMasks };
+export type MaskConfig = { pattern?: string; inputMode: InputMode; mask: TheMasks; transform?: (s: string) => string };
 
-const mask = (mask: TheMasks, inputMode: InputMode, pattern?: string): MaskConfig => ({
+const mask = (mask: TheMasks, inputMode: InputMode, props: Pick<MaskConfig, "transform" | "pattern"> = {}): MaskConfig => ({
 	mask,
 	inputMode,
-	pattern
+	...props
 });
 
 export const inputMaskedProps: Record<Masks, MaskConfig> = {
@@ -76,12 +76,12 @@ export const inputMaskedProps: Record<Masks, MaskConfig> = {
 	cellphone: mask(masks.cellphone, "tel"),
 	cep: mask(masks.cep, "decimal"),
 	cnpj: mask(masks.cnpj, "decimal"),
-	color: mask(masks.color, "decimal", "#[a-fA-F0-9]{3}([a-fA-F0-9]{3})"),
+	color: mask(masks.color, "decimal", { pattern: "#[a-fA-F0-9]{3}([a-fA-F0-9]{3})" }),
 	cpf: mask(masks.cpf, "decimal"),
-	cpfCnpj: mask(masks.cpfCnpj, "decimal"),
+	cpfCnpj: mask(masks.cpfCnpj, "decimal", { transform: numbers }),
 	creditCard: mask(masks.creditCard, "decimal"),
 	date: mask(masks.date, "decimal"),
-	int: mask(masks.int, "decimal", "[0-9]+"),
+	int: mask(masks.int, "decimal", { pattern: "[0-9]+" }),
 	isoDate: mask(masks.isoDate, "decimal"),
 	telephone: mask(masks.telephone, "tel"),
 	time: mask(masks.time, "decimal"),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { InputHTMLAttributes, DetailedHTMLProps } from "react";
+import React, { InputHTMLAttributes, DetailedHTMLProps } from "react";
 
 type NativeProps = DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
 
@@ -7,7 +7,8 @@ export type TheMaskInputProps = Omit<NativeProps, "value" | "type" | "defaultVal
 		as: "input" | React.FC<Omit<TheMaskInputProps, "as">>;
 		autoCapitalize: AutoCapitalize;
 		defaultValue: string;
-		onChangeText?: (text: string) => void;
+		transform: (value: string) => string;
+		onChangeText: (text: string) => void;
 		inputMode: InputMode;
 		mask: TheMasks;
 		tokens: Tokens;


### PR DESCRIPTION
# Motivation

Mask with `cpfCnpj` doesn't work. We need to apply a transformation in the string to make the correct algorithm in the input. Now we have the property `transform` to execute before the mask treatment