### PR TITLE
Permite uso de number no defaultValue quando o tipo de input é `int`

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -37,7 +37,7 @@ export const InputsWithDefault = () => {
 				<Input defaultValue="02134567892" mask="cpf" name="cpf" placeholder="cpf" />
 				<Input mask="creditCard" name="creditCard" placeholder="creditCard" />
 				<Input mask="date" name="date" placeholder="date" />
-				<Input mask="int" name="int" placeholder="int" />
+				<Input mask="int" name="int" placeholder="int" min={0} max={100} defaultValue={40} />
 				<Input mask="isoDate" name="isoDate" placeholder="isoDate" />
 				<Input mask="money" name="money" placeholder="money" />
 				<Input mask="telephone" name="telephone" placeholder="telephone" />

--- a/src/input.tsx
+++ b/src/input.tsx
@@ -27,11 +27,11 @@ function formatRegexMask(v: string, mask: string | Mask[], transform: (x: string
 	return output;
 }
 
-export const createPattern = (mask: TheMasks, value: string) => {
+export const createPattern = (mask: TheMasks, value: string | number) => {
 	const maskIsFunction = typeof mask === "function";
 	let result: string | Mask[] = maskIsFunction ? "" : mask;
 	if (maskIsFunction) {
-		result = mask(value);
+		result = mask(value.toString());
 	}
 	if (typeof result === "string") {
 		const len = result.length;
@@ -56,7 +56,7 @@ const MaskInput = forwardRef<HTMLInputElement, TheMaskInputProps>(
 		const [stateValue, setStateValue] = useState(() => {
 			const v = props.value ?? props.defaultValue ?? "";
 			if (mask === undefined) return v;
-			return formatRegexMask(v, typeof mask === "function" ? mask(v) : mask, transform ?? noop, tokens ?? originalTokens);
+			return formatRegexMask(v.toString(), typeof mask === "function" ? mask(v.toString()) : mask, transform ?? noop, tokens ?? originalTokens);
 		});
 
 		useEffect(() => {
@@ -64,7 +64,7 @@ const MaskInput = forwardRef<HTMLInputElement, TheMaskInputProps>(
 			setStateValue(() => {
 				const v = props.value ?? props.defaultValue ?? "";
 				if (mask === undefined) return v;
-				return formatRegexMask(v, typeof mask === "function" ? mask(v) : mask, transform ?? noop, tokens ?? originalTokens);
+				return formatRegexMask(v.toString(), typeof mask === "function" ? mask(v.toString()) : mask, transform ?? noop, tokens ?? originalTokens);
 			});
 		}, [props.value, mask, transform, props.defaultValue]);
 
@@ -98,7 +98,7 @@ const MaskInput = forwardRef<HTMLInputElement, TheMaskInputProps>(
 			event.target.value = masked;
 			onChange?.(event);
 		};
-		return <Component {...props} pattern={patternMemo} defaultValue={undefined} onChange={changeMask} value={stateValue} ref={internalRef} />;
+		return <Component {...props} pattern={patternMemo} defaultValue={undefined} onChange={changeMask} value={stateValue.toString()} ref={internalRef} />;
 	}
 );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,11 +5,11 @@ type NativeProps = DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTML
 export type TheMaskInputProps = Omit<NativeProps, "value" | "type" | "defaultValue" | "inputMode" | "autoCapitalize"> &
 	Partial<{
 		as: "input" | React.FC<Omit<TheMaskInputProps, "as">>;
-			currency: CurrencyCode;
+		currency: CurrencyCode;
 		currencyDisplay: CurrencyDisplay;
 		locale: Locales;
 		autoCapitalize: AutoCapitalize;
-		defaultValue: string;
+		defaultValue: string | number;
 		transform: (value: string) => string;
 		onChangeText: (text: string) => void;
 		inputMode: InputMode;


### PR DESCRIPTION
Quando usamos o type `int` no Input, o `defaultValue` só está aceitando o valor do tipo `string`.

Isso gera uma inconsistência já que as props `min` e `max` aceitam valores numéricos.

Por isso, o PR ajusta o tipo de variável do `defaultValue` para aceitar também valores numéricos.